### PR TITLE
Updated dependencies to work with new openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-url = "1.7.1"
-reqwest = "0.8.8"
-serde = "1"
-serde_derive = "1"
-serde_urlencoded = "0.5.3"
+url = "1.7.2"
+reqwest = "0.9.18"
+serde = "1.0.94"
+serde_derive = "1.0.94"
+serde_urlencoded = "0.5.5"
 
 [dev-dependencies]
-serde_json = "1"
+serde_json = "1.0.40"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use url::Url;
-use reqwest::{Client, StatusCode, header::ContentType};
+use reqwest::{Client, StatusCode, header::CONTENT_TYPE};
 use serde_urlencoded;
 
 use crate::{
@@ -86,11 +86,11 @@ impl ApiClient {
         let resp = self.client
             .post(url)
             .body(data)
-            .header(ContentType::form_url_encoded())
+            .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
             .send();
 
         if let Ok(mut resp) = resp {
-            if let StatusCode::Ok = resp.status() {
+            if let StatusCode::OK = resp.status() {
                 if let Ok(obj) = resp.json() {
                     Ok(obj)
                 } else {


### PR DESCRIPTION
Hi! I was doing some work with translations in Rust and came across this crate (which is really helpful). At the moment it doesn't compile because it's too far out of step with Openssl. I've made some adjustments for use in my bot which allow it to work.